### PR TITLE
fix: social logos do not have margin in footer in Safari browser

### DIFF
--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -12,7 +12,7 @@ export default function Footer(): JSX.Element {
         <div className="flex justify-center text-gray-400 md:justify-start lg:w-0 lg:flex-1">
           © Hyperjump Technology 2021
         </div>
-        <div className="flex justify-center items-center gap-8 mt-2 md:mt-0 md:justify-end md:flex-1 lg:w-0">
+        <div className="flex justify-center items-center space-x-8 mt-2 md:mt-0 md:justify-end md:flex-1 lg:w-0">
           <a
             href="https://www.linkedin.com/company/hyperjump"
             target="_blank"


### PR DESCRIPTION
This fixes issue #31 

cause of issue: Safari browser does not support [gap](https://caniuse.com/?search=gap) css property.

### How does this PR fix the issue?

change `gap-8` class with `space-x-8`