### PR TITLE
Feat: Store State to Context

### DIFF
--- a/pages/api-entry.tsx
+++ b/pages/api-entry.tsx
@@ -7,6 +7,15 @@ import Textarea from '../components/textarea';
 import { ProbeContext } from '../contexts/probe-context';
 
 export default function APIEntryPage(): JSX.Element {
+  const HTTPMethods = [
+    'GET',
+    'DELETE',
+    'HEAD',
+    'OPTIONS',
+    'PATCH',
+    'POST',
+    'PUT',
+  ];
   const router = useRouter();
   const { handleSetProbes } = useContext(ProbeContext);
   const [entries, setEntries] = useState([
@@ -99,8 +108,11 @@ export default function APIEntryPage(): JSX.Element {
                             handleFormDataChange(id, 'method', e.target.value)
                           }
                           value={method}>
-                          <SelectOption value="GET">GET</SelectOption>
-                          <SelectOption value="POST">POST</SelectOption>
+                          {HTTPMethods.map((method) => (
+                            <SelectOption key={method} value={method}>
+                              {method}
+                            </SelectOption>
+                          ))}
                         </Select>
                       </div>
                     </div>

--- a/pages/web-page.tsx
+++ b/pages/web-page.tsx
@@ -1,61 +1,108 @@
-import { FormEvent, useState } from 'react';
+import { useContext, FormEvent } from 'react';
+import { useRouter } from 'next/router';
+import { v4 as uuid } from 'uuid';
+import { Button, Form, Layout, TextInput } from '../components';
+import { useForm } from '../hooks/use-form';
+import { ProbeContext } from '../contexts/probe-context';
 
-import { Button, Layout, TextInput } from '../components';
+type ProbeRequest = {
+  id: string;
+  url: string;
+};
 
 export default function WebPage(): JSX.Element {
-  const [data, setData] = useState([{ id: 1, name: '', value: '' }]);
-
-  const addInputField = () => {
-    setData((fd) => [
-      ...fd,
-      { id: (fd[fd.length - 1]?.id ?? 0) + 1, name: '', value: '' },
-    ]);
+  const router = useRouter();
+  const { handleSetProbes } = useContext(ProbeContext);
+  const formHelper = useForm({
+    initialValues: {
+      probeRequests: [{ id: uuid(), url: '' }],
+    },
+  });
+  const { values, setFieldValue } = formHelper;
+  const { probeRequests } = values;
+  const isProbeRequestsMoreThanOne = probeRequests?.length > 1;
+  const addProbeRequests = () => {
+    setFieldValue(
+      'probeRequests',
+      probeRequests
+        ? [...probeRequests, { id: uuid(), url: '' }]
+        : [{ id: uuid(), url: '' }]
+    );
   };
+  const updateProbeRequests = (id: string, url: string) => {
+    setFieldValue(
+      'probeRequests',
+      probeRequests.map((pr: ProbeRequest) => {
+        if (pr.id === id) {
+          return { id: pr.id, url };
+        }
 
-  const removeInputField = (id: number) => {
-    setData((fd) => fd.filter((r) => r.id !== id));
+        return pr;
+      })
+    );
   };
-
+  const removeProbeRequests = (id: string) => {
+    setFieldValue(
+      'probeRequests',
+      probeRequests.filter((pr: ProbeRequest) => pr.id !== id)
+    );
+  };
   const handleNext = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    handleSetProbes(
+      probeRequests.map((pr: ProbeRequest) => ({
+        id: uuid(),
+        name: '',
+        description: '',
+        interval: 10,
+        requests: [
+          {
+            url: pr.url,
+            body: {} as JSON,
+            timeout: 10000,
+            headers: {},
+            method: 'GET',
+          },
+        ],
+        incidentThreshold: 5,
+        recoveryThreshold: 5,
+        alerts: [],
+      }))
+    );
+    router.push('/notifications');
   };
 
   return (
     <Layout>
       <div className="lg:py-20 xl:py-32 xl:px-80">
         <form className="text-sm sm:text-lg" onSubmit={handleNext}>
-          <fieldset>
-            <div className="space-y-8 mb-10">
-              <p>What is the address (URL) of the web page?</p>
-              {data.map(({ id }) => (
-                <div key={id} className="flex space-x-7 mb-6">
-                  <div className="flex-1">
-                    <TextInput
-                      id={`data${id}_name`}
-                      placeholder="https://example.com"
-                    />
-                  </div>
-                  {data.length > 1 && (
-                    <div className="self-end py-3">
-                      <button
-                        type="button"
-                        className="cursor-pointer underline focus:outline-none"
-                        onClick={() => removeInputField(id)}>
-                        Remove
-                      </button>
-                    </div>
-                  )}
+          <Form.Item label="What is the address (URL) of the web page?">
+            {probeRequests.map(({ id }: ProbeRequest) => (
+              <div key={id} className="flex space-x-7 mb-6">
+                <div className="flex-1">
+                  <TextInput
+                    id={`data${id}_name`}
+                    onChange={(e) => updateProbeRequests(id, e.target.value)}
+                    type="url"
+                    placeholder="https://example.com"
+                  />
                 </div>
-              ))}
-              <button
-                className="cursor-pointer underline focus:outline-none"
-                type="button"
-                onClick={addInputField}>
-                Add another URL
-              </button>
-            </div>
-          </fieldset>
-          <div className="mt-12 py-3 space-x-7">
+                {isProbeRequestsMoreThanOne && (
+                  <div className="self-end py-3">
+                    <Button
+                      variant="text"
+                      onClick={() => removeProbeRequests(id)}>
+                      Remove
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ))}
+            <Button variant="text" type="button" onClick={addProbeRequests}>
+              Add another URL
+            </Button>
+          </Form.Item>
+          <div className="py-3 space-x-7">
             <Button type="button" outline>
               Back
             </Button>


### PR DESCRIPTION
### What does this PR solve?
Store state to context for api-entry, web-form, and web-page page. Resolves #38

### How do you implement this?
When user click Next button on the page, local state will store to global context.

### How do I test this?
1. Run `npm run dev`
2. Open api-entry, web-form, and web-page page
3. Fill in the form
4. Click next button
5. See context changes in ProbeProvider component using [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) on Chrome
