### PR TITLE
Issue/58 minimal 1 alert

### DIFF
--- a/components/checkbox/index.tsx
+++ b/components/checkbox/index.tsx
@@ -14,6 +14,7 @@ export default function Checkbox({
   help,
   value,
   name,
+  disabled,
   defaultChecked,
   onChange,
 }: CheckboxProps): JSX.Element {
@@ -24,6 +25,7 @@ export default function Checkbox({
           id={value}
           name={name}
           type="checkbox"
+          disabled={disabled}
           defaultChecked={defaultChecked}
           className="focus:ring-indigo-500 h-5 w-5 text-indigo-600 border-gray-300"
           onChange={onChange}

--- a/components/probe-card/index.tsx
+++ b/components/probe-card/index.tsx
@@ -116,7 +116,7 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                     name={`probe_${id}_status_not_2xx`}
                     value="status-not-2xx"
                     disabled={
-                      probe.alerts.length < 2 &&
+                      probe.alerts?.length < 2 &&
                       isAlertSelected('status-not-2xx')
                     }
                     help="Checks if status code is not 2xx (200-204)"
@@ -137,7 +137,7 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                   <ProbeResponseTime
                     probeId={id}
                     disabled={
-                      probe.alerts.length < 2 &&
+                      probe.alerts?.length < 2 &&
                       isAlertSelected('response-time-greater-than')
                     }
                     defaultChecked={

--- a/components/probe-card/index.tsx
+++ b/components/probe-card/index.tsx
@@ -136,6 +136,9 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                   </Checkbox>
                   <ProbeResponseTime
                     probeId={id}
+                    alert={probe?.alerts?.find((alert) =>
+                      alert.includes('response-time-greater-than-')
+                    )}
                     disabled={
                       probe.alerts?.length < 2 &&
                       isAlertSelected('response-time-greater-than')

--- a/components/probe-card/index.tsx
+++ b/components/probe-card/index.tsx
@@ -26,6 +26,12 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
     handleRemoveProbe,
   } = useContext(ProbeContext);
 
+  const isAlertSelected = (alert: string) => {
+    const exists = probe.alerts.filter((item: string) => item.includes(alert));
+    if (exists.length > 0) return true;
+    return false;
+  };
+
   return (
     <div className="border border-solid rounded-md mb-8">
       <div className="flex flex-row items-center justify-between p-4 bg-gray-50 border-b">
@@ -105,10 +111,14 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                   <p className="text-sm sm:text-lg">seconds</p>
                 </div>
                 <div className="flex flex-col space-y-4 space-x-4">
-                  <p className="text-sm sm:text-lg">Notify on</p>
+                  <p className="text-sm sm:text-lg">Notify on (min. 1):</p>
                   <Checkbox
                     name={`probe_${id}_status_not_2xx`}
                     value="status-not-2xx"
+                    disabled={
+                      probe.alerts.length < 2 &&
+                      isAlertSelected('status-not-2xx')
+                    }
                     help="Checks if status code is not 2xx (200-204)"
                     defaultChecked={
                       probe?.alerts?.find((alert) => alert === 'status-not-2xx')
@@ -126,9 +136,13 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                   </Checkbox>
                   <ProbeResponseTime
                     probeId={id}
+                    disabled={
+                      probe.alerts.length < 2 &&
+                      isAlertSelected('response-time-greater-than')
+                    }
                     defaultChecked={
                       probe?.alerts?.find((alert) =>
-                        alert.includes('response-time-greater-than')
+                        alert.includes('response-time-greater-than-')
                       )
                         ? true
                         : false

--- a/components/probe-response-time/index.tsx
+++ b/components/probe-response-time/index.tsx
@@ -3,24 +3,35 @@ import {
   InputHTMLAttributes,
   useState,
   useContext,
+  useEffect,
 } from 'react';
 import { TextInput, Checkbox } from '..';
 import { ProbeContext } from '../../contexts/probe-context';
+import { parseAlertStringTime } from '../../utils/parse-alert-string-time';
 
 export interface ProbeResponseTimeProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
   probeId: string;
+  alert: string | undefined;
   defaultChecked: boolean;
 }
 
 const ProbeResponseTime: FunctionComponent<ProbeResponseTimeProps> = ({
   probeId,
+  alert,
   defaultChecked,
   disabled,
 }) => {
   const { handleUpdateProbeResponseTimeAlert } = useContext(ProbeContext);
-  const [responseTime, setResponseTime] = useState(2000);
+  const [responseTime, setResponseTime] = useState(0);
   const [checked, setChecked] = useState(true);
+
+  useEffect(() => {
+    if (alert) {
+      const newResponseTime = parseAlertStringTime(alert);
+      setResponseTime(newResponseTime);
+    }
+  }, [alert]);
 
   const handleUpdateResponseTime = (
     probeId: string,

--- a/components/probe-response-time/index.tsx
+++ b/components/probe-response-time/index.tsx
@@ -16,6 +16,7 @@ export interface ProbeResponseTimeProps
 const ProbeResponseTime: FunctionComponent<ProbeResponseTimeProps> = ({
   probeId,
   defaultChecked,
+  disabled,
 }) => {
   const { handleUpdateProbeResponseTimeAlert } = useContext(ProbeContext);
   const [responseTime, setResponseTime] = useState(2000);
@@ -31,6 +32,8 @@ const ProbeResponseTime: FunctionComponent<ProbeResponseTimeProps> = ({
     handleUpdateProbeResponseTimeAlert(probeId, value, checked);
   };
 
+  console.log(disabled);
+
   return (
     <Checkbox
       name={`probe_${probeId}_response_time`}
@@ -38,6 +41,7 @@ const ProbeResponseTime: FunctionComponent<ProbeResponseTimeProps> = ({
       help="Response time is longer than xxx milliseconds"
       defaultChecked={defaultChecked}
       checked={true}
+      disabled={disabled}
       onChange={(e) =>
         handleUpdateResponseTime(probeId, responseTime, e.target.checked)
       }>

--- a/components/probe-response-time/index.tsx
+++ b/components/probe-response-time/index.tsx
@@ -12,7 +12,7 @@ import { parseAlertStringTime } from '../../utils/parse-alert-string-time';
 export interface ProbeResponseTimeProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
   probeId: string;
-  alert: string | undefined;
+  alert?: string;
   defaultChecked: boolean;
 }
 

--- a/components/probe-response-time/index.tsx
+++ b/components/probe-response-time/index.tsx
@@ -32,8 +32,6 @@ const ProbeResponseTime: FunctionComponent<ProbeResponseTimeProps> = ({
     handleUpdateProbeResponseTimeAlert(probeId, value, checked);
   };
 
-  console.log(disabled);
-
   return (
     <Checkbox
       name={`probe_${probeId}_response_time`}

--- a/contexts/importer.ts
+++ b/contexts/importer.ts
@@ -46,13 +46,13 @@ const checkProbeAlerts = (probes: Probe[]) => {
     if (!item.alerts)
       return {
         ...item,
-        alerts: ['status-not-2xx', 'response-time-greater-than-2-s'],
+        alerts: ['status-not-2xx', 'response-time-greater-than-2000-ms'],
       };
 
     return item.alerts?.length === 0
       ? {
           ...item,
-          alerts: ['status-not-2xx', 'response-time-greater-than-2-s'],
+          alerts: ['status-not-2xx', 'response-time-greater-than-2000-ms'],
         }
       : item;
   });

--- a/contexts/importer.ts
+++ b/contexts/importer.ts
@@ -23,7 +23,8 @@ export const useConfigFileImporter = () => {
           } = JSON.parse(String(reader.result));
 
           if (probes) {
-            handleSetProbes(probes);
+            const finalProbes = checkProbeAlerts(probes);
+            handleSetProbes(finalProbes);
           } else {
             throw new Error('something wrong in probes key');
           }
@@ -38,4 +39,23 @@ export const useConfigFileImporter = () => {
 
       reader.readAsText(file);
     });
+};
+
+const checkProbeAlerts = (probes: Probe[]) => {
+  const validated = probes.map((item: Probe) => {
+    if (!item.alerts)
+      return {
+        ...item,
+        alerts: ['status-not-2xx', 'response-time-greater-than-2-s'],
+      };
+
+    return item.alerts?.length === 0
+      ? {
+          ...item,
+          alerts: ['status-not-2xx', 'response-time-greater-than-2-s'],
+        }
+      : item;
+  });
+
+  return validated;
 };

--- a/utils/parse-alert-string-time.ts
+++ b/utils/parse-alert-string-time.ts
@@ -1,0 +1,14 @@
+// parse string like "response-time-greater-than-200-ms" and return the time in ms
+export const parseAlertStringTime = (str: string): number => {
+  // match any string that ends with digits followed by unit 's' or 'ms'
+  const match = str.match(/(\d+)-(m?s)$/);
+  if (!match) {
+    throw new Error('alert string does not contain valid time number');
+  }
+
+  const number = Number(match[1]);
+  const unit = match[2];
+
+  if (unit === 's') return number * 1000;
+  return number;
+};


### PR DESCRIPTION
# Monika Config Generator PR

## What does this PR solves? 

This PR resolves #58 

## How does this PR solve the problem?

This PR disables alerts checkbox when only there is 1 checkbox selected in Probe Alerts Form. This PR also set default notifications when importing configurations without alerts

## How to Test

1. Run the app
2. Copy the minimal configurations below and save it in your local desktop:
```json
{
  "probes": [
    {
      "requests": [
        {
          "url": "https://github.com"
        }
      ]
    }
  ]
}
```
3. Open the browser localhost:3000 and select "I have a configuration file". Select the configuration file that you just saved.
4. After the browser navigated to the new page, check the alerts section. Is it already set as checked? If yes, continue.
5. Uncheck the "status not 2xx" checkbox. Is the "response time greater than" checkbox is now cannot be unchecked? If yes, continue
5. Uncheck the "response time greater than" checkbox. Is the "status not 2xx" checkbox is now cannot be unchecked? If yes, then you can approve this PR