### PR TITLE
Fix: No Recipients Defined on SMTP Notification

### DIFF
--- a/pages/notifications.tsx
+++ b/pages/notifications.tsx
@@ -545,9 +545,11 @@ function getEmailNotificationData(
         id,
         type: formData?.emailService,
         data: {
-          recipients: formData?.recipients,
+          recipients: formData?.recipients.map(
+            (recipient: Recipient) => recipient.email
+          ),
           hostname: formData?.hostname,
-          port: formData?.port,
+          port: parseInt(formData?.port ?? 0),
           username: formData?.username,
           password: formData?.password,
         },
@@ -557,7 +559,9 @@ function getEmailNotificationData(
         id,
         type: formData?.emailService,
         data: {
-          recipients: formData?.recipients,
+          recipients: formData?.recipients.map(
+            (recipient: Recipient) => recipient.email
+          ),
           apiKey: formData?.apiKey,
           domain: formData?.domain,
         },
@@ -567,7 +571,9 @@ function getEmailNotificationData(
         id,
         type: formData?.emailService,
         data: {
-          recipients: formData?.recipients,
+          recipients: formData?.recipients.map(
+            (recipient: Recipient) => recipient.email
+          ),
           apiKey: formData?.apiKey,
         },
       };


### PR DESCRIPTION
### What does this PR solve?
Fix no recipients defined on SMTP notification. Fixes #60

### How do you implement this?
Change SMTP recipients data format

### How do I test this?
1. Open Monika config generator
2. Select I'm New to monika
3. Select web page
4. Enter few urls
5. On notification page, send email, specify SMTP server.
6. Generate config.
7. Use the config in Monika.