### PR TITLE
fix github actions google analytics

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,11 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12
+      - run: npm ci
+      - run: npm run build
         env:
           CI: true
           NEXT_PUBLIC_GA_ID: ${{ secrets.GA_ID }}
-      - run: npm ci
-      - run: npm run build
       - run: npm run export
       - run: touch out/.nojekyll
         env:


### PR DESCRIPTION
fixing PR #65 

by moving add env in `npm run build` command

### how to test

in actions, when i console.log the process.env, it prints the value GA_TRACKING_ID of `***`  instead of undefined
<img width="478" alt="Screen Shot 2021-04-27 at 20 53 38" src="https://user-images.githubusercontent.com/5974862/116253809-01fc1800-a79b-11eb-902e-df438a8cd975.png">
