### PR TITLE
Feat: Add Facebook Workplace and Monika WhatsApp Notifier Notification Channel

### DIFF
--- a/utils/notification-forms.ts
+++ b/utils/notification-forms.ts
@@ -1,10 +1,12 @@
 import {
   MailgunData,
+  MonikaNotifData,
   SendgridData,
   SMTPData,
   TeamsData,
   TelegramData,
   WebhookData,
+  WorkplaceData,
 } from '@hyperjumptech/monika/lib/interfaces/data';
 
 interface NotificationForm<T> {
@@ -174,10 +176,49 @@ export const teamsForm: NotificationForm<Omit<TeamsData, 'body'>>[] = [
   },
 ];
 
+const monikaWhatsAppForm: NotificationForm<Omit<MonikaNotifData, 'body'>>[] = [
+  {
+    label: 'Monika WhatsApp Notifier',
+    name: 'monika-notif',
+    fields: [
+      {
+        label: 'Webhook URL',
+        name: 'url',
+      },
+    ],
+    defaultValue: {
+      url: '',
+    },
+  },
+];
+
+const workplaceForm: NotificationForm<Omit<WorkplaceData, 'body'>>[] = [
+  {
+    label: 'Facebook Workplace',
+    name: 'workplace',
+    fields: [
+      {
+        label: 'Thread ID',
+        name: 'thread_id',
+      },
+      {
+        label: 'Access Token',
+        name: 'access_token',
+      },
+    ],
+    defaultValue: {
+      thread_id: '',
+      access_token: '',
+    },
+  },
+];
+
 export const notificationForms = [
   smtpForm,
   mailgunForm,
   sendgridForm,
+  monikaWhatsAppForm,
+  workplaceForm,
   slackForm,
   teamsForm,
   telegramForm,


### PR DESCRIPTION
### What does this PR solve?
Add Facebook workplace and Monika WhatsApp Notifier notification channels. Resolves #73. 

### How do you implement this?
1. Add Facebook workplace and Monika WhatsApp Notifier on /notifications and /advanced page.

### How do I test this?

#### on /notifications page
1. Run `npm run dev`.
2. Select `I'm New to monika`.
3. Click `Next`.
4. Select `Web page`.
5. Input one or more URL.
6. Choose `Facebook Workplace` or `Monika WhatsApp Notifier`.
7. Input the data.
8. Click `Next`.
9. Click `Download Config file`.

#### on  /advanced page
1. Run `npm run dev`.
2. Select `I have used Monika before`.
3. Click `Next`.
4. Click `Notification` Tab on the left.
6. Choose `Facebook Workplace` or `Monika WhatsApp Notifier`.
7. Input the data.
7. Click `Generate Config File`.