### PR TITLE
fix: 404 images

### DIFF
--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -5,7 +5,11 @@ export default function Footer(): JSX.Element {
       <a
         className="flex flex-col lg:flex-row"
         href="https://monika.hyperjump.tech/">
-        <img className="w-16 h-4 mt-1" src={'/monika.svg'} alt="Monika Logo" />
+        <img
+          className="w-16 h-4 mt-1"
+          src="/monika-config-generator/monika.svg"
+          alt="Monika Logo"
+        />
       </a>
       <div className="flex flex-col mt-4 lg:mt-0">
         <p className="font-bold">Resources</p>
@@ -64,7 +68,10 @@ export default function Footer(): JSX.Element {
           href="https://hyperjump.tech/"
           target="_blank"
           rel="noopener noreferrer">
-          <img src="/hyperjump.svg" alt="Hyperjump Logo" />
+          <img
+            src="/monika-config-generator/hyperjump.svg"
+            alt="Hyperjump Logo"
+          />
         </a>
         <p className="text-xs pt-2">
           PT Artha Rajamas Mandiri (Hyperjump) is an open-source-first company

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -22,7 +22,7 @@ export default function Header({
                 <span className="sr-only">Monika Configuration Generator</span>
                 <img
                   className="w-auto h-4"
-                  src="/monika.svg"
+                  src="/monika-config-generator/monika.svg"
                   alt="Monika Logo"
                 />
               </a>
@@ -119,7 +119,7 @@ export default function Header({
               <div>
                 <img
                   className="h-4 w-auto"
-                  src="/monika.svg"
+                  src="/monika-config-generator/monika.svg"
                   alt="Monika Logo"
                 />
               </div>

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -27,7 +27,11 @@ function Content({ children }: LayoutProps): JSX.Element {
         {children}
       </main>
       <div className="absolute inset-x-0 bottom-0">
-        <img className="w-full" src="/wave-monika.svg" alt="wave background" />
+        <img
+          className="w-full"
+          src="/monika-config-generator/wave-monika.svg"
+          alt="wave background"
+        />
         <div className="w-full h-px bg-gradient-to-r from-purple to-aqua" />
       </div>
     </div>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,6 +26,10 @@ export default class MyDocument extends Document {
           `,
             }}
           />
+          <link
+            rel="shortcut icon"
+            href="/monika-config-generator/favicon.ico"
+          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
This PR fixes not found images in some places since previous UI revamp

### How do you fix it?
Using references before UI revamp, I fix this by adding base path to the leading images' path, that is `/monika-config-generator/`. Since assets are placed under that sub-path of our domain, e.g., [this logo](https://hyperjumptech.github.io/monika-config-generator/monika.svg)

NB: Currently, no way to test it on local machine.