### PR TITLE
Prepare move to new site

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a web app to help generate a configuration file for [Monika, the open so
 
 ## How to use
 
-Go to [the Monika Config Generator web app](https://hyperjumptech.github.io/monika-config-generator/).
+Go to [the Monika Config Generator web app](https://monika-config.hyperjump.tech/).
 
 ## Development
 

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -25,7 +25,7 @@ export default function Footer(): JSX.Element {
         </a>
         <a
           className="text-xs pt-1"
-          href="https://monika-config.hyperjump.tech/"
+          href="/"
           target="_blank"
           rel="noopener noreferrer">
           Config Generator

--- a/components/footer/index.tsx
+++ b/components/footer/index.tsx
@@ -5,11 +5,7 @@ export default function Footer(): JSX.Element {
       <a
         className="flex flex-col lg:flex-row"
         href="https://monika.hyperjump.tech/">
-        <img
-          className="w-16 h-4 mt-1"
-          src="/monika-config-generator/monika.svg"
-          alt="Monika Logo"
-        />
+        <img className="w-16 h-4 mt-1" src="/monika.svg" alt="Monika Logo" />
       </a>
       <div className="flex flex-col mt-4 lg:mt-0">
         <p className="font-bold">Resources</p>
@@ -29,7 +25,7 @@ export default function Footer(): JSX.Element {
         </a>
         <a
           className="text-xs pt-1"
-          href="https://hyperjumptech.github.io/monika-config-generator/"
+          href="https://monika-config.hyperjump.tech/"
           target="_blank"
           rel="noopener noreferrer">
           Config Generator
@@ -68,10 +64,7 @@ export default function Footer(): JSX.Element {
           href="https://hyperjump.tech/"
           target="_blank"
           rel="noopener noreferrer">
-          <img
-            src="/monika-config-generator/hyperjump.svg"
-            alt="Hyperjump Logo"
-          />
+          <img src="/hyperjump.svg" alt="Hyperjump Logo" />
         </a>
         <p className="text-xs pt-2">
           PT Artha Rajamas Mandiri (Hyperjump) is an open-source-first company

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -22,7 +22,7 @@ export default function Header({
                 <span className="sr-only">Monika Configuration Generator</span>
                 <img
                   className="w-auto h-4"
-                  src="/monika-config-generator/monika.svg"
+                  src="/monika.svg"
                   alt="Monika Logo"
                 />
               </a>
@@ -119,7 +119,7 @@ export default function Header({
               <div>
                 <img
                   className="h-4 w-auto"
-                  src="/monika-config-generator/monika.svg"
+                  src="/monika.svg"
                   alt="Monika Logo"
                 />
               </div>

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -27,11 +27,7 @@ function Content({ children }: LayoutProps): JSX.Element {
         {children}
       </main>
       <div className="absolute inset-x-0 bottom-0">
-        <img
-          className="w-full"
-          src="/monika-config-generator/wave-monika.svg"
-          alt="wave background"
-        />
+        <img className="w-full" src="/wave-monika.svg" alt="wave background" />
         <div className="w-full h-px bg-gradient-to-r from-purple to-aqua" />
       </div>
     </div>

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,0 @@
-const isProd = (process.env.NODE_ENV || 'production') === 'production';
-
-module.exports = {
-  basePath: isProd ? '/monika-config-generator' : '',
-  assetPrefix: isProd ? '/monika-config-generator/' : '',
-};

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,10 +26,6 @@ export default class MyDocument extends Document {
           `,
             }}
           />
-          <link
-            rel="shortcut icon"
-            href="/monika-config-generator/favicon.ico"
-          />
         </Head>
         <body>
           <Main />

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,5 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-
-export default (req: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json({ name: 'John Doe' });
-};


### PR DESCRIPTION
Since the site is moved to https://monika-config.hyperjump.tech/, domain sub-path `/monika-config-generator` in existing links needed to be removed.

### How to test
- `npm run dev`
- Visit localhost:3000
- Images and favicon should be displayed correctly
- `Config Generator` menus should be pointing to root