### PR TITLE
feat: disable changing number value in a text field by scrolling

### DIFF
--- a/components/probe-card/index.tsx
+++ b/components/probe-card/index.tsx
@@ -97,7 +97,9 @@ const ProbeCard: FunctionComponent<ProbeCardProps> = ({ probe, id }) => {
                     id={`probe_${id}_interval`}
                     type="number"
                     placeholder="10"
+                    min="1"
                     value={probe.interval}
+                    onWheel={(e) => (e.target as any).blur()}
                     onChange={(event) => {
                       handleUpdateProbeData({
                         id,

--- a/components/probe-request-form/index.tsx
+++ b/components/probe-request-form/index.tsx
@@ -221,6 +221,7 @@ const ProbeRequestForm: FunctionComponent<ProbeRequestFormProps> = ({
             min={1}
             value={request.timeout}
             className="w-full md:w-64"
+            onWheel={(e) => (e.target as any).blur()}
             onChange={(event) => {
               handleUpdateProbeRequestData({
                 id: probeId,

--- a/components/probe-threshold/index.tsx
+++ b/components/probe-threshold/index.tsx
@@ -36,7 +36,9 @@ const ProbeThreshold: FunctionComponent<ProbeResponseTimeProps> = ({
       id={`probe_${probeId}_threshold`}
       type="number"
       placeholder="5"
+      min="1"
       value={threshold}
+      onWheel={(e) => (e.target as any).blur()}
       onChange={(event) => onThresholdChange(event.target.value)}
     />
   );


### PR DESCRIPTION
### What feature/issue does this PR add
Disable changing number value in a text field by scrolling. Resolve #101.

### How did you implement / how did you fix it
- Blur the input when wheel event fired

### How to test
- Run `npm run dev`
- Open `http://localhost:3000`
- Choose `I have used Monika before` and click Next
- Click `timeout/interval/threshold` input text and scroll