### PR TITLE
Fix: Imported JSON has wrong threshold

### DIFF
--- a/components/probe-threshold/index.tsx
+++ b/components/probe-threshold/index.tsx
@@ -1,9 +1,4 @@
-import {
-  InputHTMLAttributes,
-  FunctionComponent,
-  useState,
-  useContext,
-} from 'react';
+import { InputHTMLAttributes, FunctionComponent, useContext } from 'react';
 import { TextInput } from '..';
 import { ProbeContext } from '../../contexts/probe-context';
 
@@ -15,10 +10,9 @@ export interface ProbeResponseTimeProps
 const ProbeThreshold: FunctionComponent<ProbeResponseTimeProps> = ({
   probeId,
 }) => {
-  const { handleUpdateProbeData } = useContext(ProbeContext);
-  const [threshold, setThreshold] = useState(5);
+  const { handleUpdateProbeData, probeData } = useContext(ProbeContext);
+  const probe = probeData.find((probe) => probe.id === probeId);
   const onThresholdChange = (value: string) => {
-    setThreshold(parseInt(value, 10));
     handleUpdateProbeData({
       id: probeId,
       field: 'incidentThreshold',
@@ -37,7 +31,10 @@ const ProbeThreshold: FunctionComponent<ProbeResponseTimeProps> = ({
       type="number"
       placeholder="5"
       min="1"
-      value={threshold}
+      value={Math.max(
+        probe?.incidentThreshold || 0,
+        probe?.recoveryThreshold || 0
+      )}
       onWheel={(e) => (e.target as any).blur()}
       onChange={(event) => onThresholdChange(event.target.value)}
     />


### PR DESCRIPTION
## What feature/issue does this PR add
Imported JSON has wrong threshold. Resolve #100.

## How did you implement / how did you fix it
Get threshold value from context.

## How to test
- Run npm run dev
- Open http://localhost:3000
- Choose I have a configuration file and click Next
- Import config file
```json
{
  "notifications": [],
  "probes": [
    {
      "id": "2",
      "name": "github.com",
      "description": "Landing page of github.com",
      "interval": 20,
      "incidentThreshold": 10,
      "recoveryThreshold": 10,
      "requests": [
        {
          "url": "https://github.com"
        }
      ],
      "alerts": [
        {
          "query": "response.status < 200 or response.status > 299"
        },
        {
          "query": "response.time > 2000"
        }
      ]
    }
  ]
}
```